### PR TITLE
Fix working draft preview link

### DIFF
--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -15,13 +15,13 @@ jobs:
       run: apk add --update git
 
     - name: install asciidoctor-bibtex
-      run: gem install asciidoctor-bibtex
+      run: gem install asciidoctor-bibtex asciidoctor-mathematical
 
     - name: checkout
       uses: actions/checkout@master
 
     - name: build AcMeta.adoc
-      run: asciidoctor -r asciidoctor-bibtex --backend html5 -a data-uri acmeta.adoc
+      run: asciidoctor -r asciidoctor-bibtex -r asciidoctor-mathematical --backend html5 -a data-uri -a mathematical-format=svg acmeta.adoc
       working-directory: docs
 
     - name: move AcMeta file to report folder

--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ This repository contains the text and source files necessary to generate _A meta
 Version 1.10 of the AcMeta convention (as ICES SISP 4-TG-AcMeta) is available https://www.ices.dk/sites/pub/Publication%20Reports/ICES%20Survey%20Protocols%20(SISP)/SISP-4%20A%20metadata%20convention%20for%20processed%20acoustic%20data%20from%20active%20acoustic%20systems.pdf[here]. Previous published versions were 1.0 (2013) and 1.05 (2014).
 
 == Preview of the current working draft
-The current working draft of the acoustic metadata convention is in the `Formatted_docs` folder as an HTML file. To view a rendering of convention in your web browser, please go https://gitcdn.link/repo/ices-publications/AcMeta/master/Formatted_docs/TG-AcMeta.html[here] (note that this can be up to two hours out-of-date).
+The current working draft of the acoustic metadata convention is in the `Formatted_docs` folder as an HTML file. To view a rendering of convention in your web browser, please go https://htmlpreview.github.io/?https://github.com/ices-publications/AcMeta/blob/master/Formatted_docs/TG-AcMeta.html[here] (note that it takes a few minutes for new changes to appear).
 
 image:https://github.com/ices-publications/AcMeta/workflows/BuildDocuments/badge.svg[]
 


### PR DESCRIPTION
The free server that provided the preview of the latest working draft has disappeared from the internet...

This PR changes to a different method that uses github itself, so should be longer lasting... This new method didn't work with the mathML in the preview, so this PR also gets asciidoctor to inline the equations/symbols as svg instead of using mathML.



